### PR TITLE
Update version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-ui-router",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Redux middleware for use with Angular UI Router",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
npm version states 0.2.0, package.json states 0.1.4, I did a diff between the two and didn't find any difference, so I guess the version bump was just not checked in.
This is just to to clarify that this version is indeed the last.