### PR TITLE
- v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "redux-ui-router",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Redux middleware for use with Angular UI Router",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "scripts": {
     "lint": "node node_modules/.bin/eslint src",
     "clean": "rm -rf lib",

--- a/src/router-listener.js
+++ b/src/router-listener.js
@@ -9,7 +9,7 @@
 export default function RouterListener($rootScope, ngUiStateChangeActions) {
 
   $rootScope.$on('$stateChangeStart', ngUiStateChangeActions.onStateChangeStart);
-  $rootScope.$on('$locationChangeSuccess', ngUiStateChangeActions.onStateChangeSuccess);
+  $rootScope.$on('$stateChangeSuccess', ngUiStateChangeActions.onStateChangeSuccess);
 
   $rootScope.$on('$stateChangeError', ngUiStateChangeActions.onStateChangeError);
   $rootScope.$on('$stateNotFound', ngUiStateChangeActions.onStateNotFound);

--- a/src/router-middleware.js
+++ b/src/router-middleware.js
@@ -12,7 +12,21 @@ export default function routerMiddleware($state) {
     switch (action.type) {
       case STATE_GO:
         return $state.go(payload.to, payload.params, payload.options)
-          .then(next(action));
+          .then(() => {
+            if ($state.current.reloadOnSearch === false) {
+              next({
+                type: STATE_CHANGE_SUCCESS,
+                payload: {
+                  currentState: $state.current,
+                  currentParams: $state.params,
+                  prevState: getState().router.get('currentState'),
+                  prevParams: getState().router.get('currentParams')
+                }
+              });
+            }
+
+            next(action);
+          });
 
       case STATE_RELOAD:
         return $state.reload(payload)
@@ -26,10 +40,10 @@ export default function routerMiddleware($state) {
         return next({
           type: STATE_CHANGE_SUCCESS,
           payload: {
-            currentParams: $state.params,
-            currentState: $state.current,
-            prevState: getState().router.get('currentState', {}).toJS(),
-            prevParams: getState().router.get('currentParams', {}).toJS()
+            currentState: payload.toState,
+            currentParams: payload.toParams,
+            prevState: payload.fromState,
+            prevParams: payload.fromParams
           }
         });
 

--- a/src/state-change-success.js
+++ b/src/state-change-success.js
@@ -8,8 +8,29 @@ import { STATE_CHANGE_SUCCESS } from './action-types';
  *
  * @return {Object} Action object
  */
-export default function onStateChangeSuccess() {
+
+/**
+ * This action is triggered when a $stateChangeSuccess event is broadcast.
+ * Accepts a payload which matches the UI Router $stateChangeSuccess event.
+ *
+ * http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state
+ *
+ * @param {Object} event State change event
+ * @param {Object} toState To state definition
+ * @param {Object} toParams To state params
+ * @param {Object} fromState From state definition
+ * @param {Object} fromParams From state params
+ * @return {Object} Action object
+ */
+export default function onStateChangeSuccess(event, toState, toParams, fromState, fromParams) {
   return {
-    type: STATE_CHANGE_SUCCESS
+    type: STATE_CHANGE_SUCCESS,
+    payload: {
+      event,
+      toState,
+      toParams,
+      fromState,
+      fromParams
+    }
   };
 }

--- a/src/state-transition-to.js
+++ b/src/state-transition-to.js
@@ -14,6 +14,10 @@ import { STATE_TRANSITION_TO } from './action-types';
 export default function stateTransitionTo(to, toParams, options) {
   return {
     type: STATE_TRANSITION_TO,
-    payload: { to, toParams, options }
+    payload: {
+      to,
+      toParams,
+      options
+    }
   };
 }


### PR DESCRIPTION
- Reverted $locationChangeSuccess change, back to using
  $stateChangeSuccess
- Had issues with $locationChangeSuccess firing with no data on startup,
  $state is not ready at that time
- Forcing $stateChangeSuccess action to fire when a $state.go resolves
  and reloadOnSearch is set to false