### PR TITLE
Remove immutablejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "license": "ISC",
   "dependencies": {
     "babel": "5.8.21",
-    "immutable": "3.7.4",
     "redux": "3.0.0",
     "redux-actions": "^0.8.0"
   },

--- a/src/__tests__/router-state-reducer.test.js
+++ b/src/__tests__/router-state-reducer.test.js
@@ -9,10 +9,10 @@ describe('routerStateReducer', () => {
     };
 
     let state = routerStateReducer(undefined, action);
-    expect(state.toJS().currentState).to.deep.equal({});
-    expect(state.toJS().currentParams).to.deep.equal({});
-    expect(state.toJS().prevState).to.deep.equal({});
-    expect(state.toJS().prevParams).to.deep.equal({});
+    expect(state.currentState).to.deep.equal({});
+    expect(state.currentParams).to.deep.equal({});
+    expect(state.prevState).to.deep.equal({});
+    expect(state.prevParams).to.deep.equal({});
   });
 
   it('should set the provided state if the $stateChangeSuccess type is used', () => {
@@ -27,9 +27,9 @@ describe('routerStateReducer', () => {
     };
 
     let state = routerStateReducer(undefined, action);
-    expect(state.toJS().currentState).to.equal('currentState');
-    expect(state.toJS().currentParams).to.equal('currentParams');
-    expect(state.toJS().prevState).to.equal('prevState');
-    expect(state.toJS().prevParams).to.equal('prevParams');
+    expect(state.currentState).to.equal('currentState');
+    expect(state.currentParams).to.equal('currentParams');
+    expect(state.prevState).to.equal('prevState');
+    expect(state.prevParams).to.equal('prevParams');
   });
 });

--- a/src/router-state-reducer.js
+++ b/src/router-state-reducer.js
@@ -1,12 +1,11 @@
 import { STATE_CHANGE_SUCCESS } from './action-types';
-import { fromJS } from 'immutable';
 
-const INITIAL_STATE = fromJS({
+const INITIAL_STATE = {
   currentState: {},
   currentParams: {},
   prevState: {},
   prevParams: {}
-});
+};
 
 /**
  * Reducer of STATE_CHANGE_SUCCESS actions. Returns a state object
@@ -18,6 +17,6 @@ const INITIAL_STATE = fromJS({
  */
 export default function routerStateReducer(state = INITIAL_STATE, action) {
   return action.type === STATE_CHANGE_SUCCESS
-    ? state.merge(fromJS(action.payload))
+    ? action.payload
     : state;
 }


### PR DESCRIPTION
After looking quickly, there is no need for any `_.assign` `_.merge` or whatever, since we just want the current state of ui-router every time. So we can just return the payload of the action directly.
I'm not very familiar with ui-router so feel free to tell me if i'm missing something here.