### PR TITLE
[#21] fix issue with initial state not existing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-ui-router",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Redux middleware for use with Angular UI Router",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/router-listener.js
+++ b/src/router-listener.js
@@ -7,7 +7,7 @@
  * @param {object} accountSelectActions Dependency
  * @return {undefined} undefined
  */
-export default function RouterListener($rootScope, $urlRouter, ngUiStateChangeActions) {
+export default function RouterListener($rootScope, $urlRouter, $stateParams, ngUiStateChangeActions) {
 
   $rootScope.$on('$stateChangeStart', ngUiStateChangeActions.onStateChangeStart);
 
@@ -17,6 +17,11 @@ export default function RouterListener($rootScope, $urlRouter, ngUiStateChangeAc
     ngUiStateChangeActions.onStateChangeSuccess();
   });
 
+  let unsubcribeStateChangeListener = $rootScope.$on('$stateChangeSuccess', () => {
+    ngUiStateChangeActions.onStateChangeSuccess();
+    unsubcribeStateChangeListener();
+  });
+
   $rootScope.$on('$stateChangeError', ngUiStateChangeActions.onStateChangeError);
   $rootScope.$on('$stateNotFound', ngUiStateChangeActions.onStateNotFound);
 }
@@ -24,6 +29,6 @@ export default function RouterListener($rootScope, $urlRouter, ngUiStateChangeAc
 RouterListener.$inject = [
   '$rootScope',
   '$urlRouter',
+  '$stateParams',
   'ngUiStateChangeActions'
 ];
-


### PR DESCRIPTION
Fixes issue https://github.com/neilff/redux-ui-router/issues/21

`$locationChangeSuccess` does not provide the state for the application on start up. To fix this, we listen to `$stateChangeSuccess` on init, and then unbind that listener after the event fires the first them and then rely on `$locationChangeSuccess`