### PR TITLE
Pass the event of ui-router in the payloads

### DIFF
--- a/src/__tests__/router-state-reducer.test.js
+++ b/src/__tests__/router-state-reducer.test.js
@@ -1,4 +1,4 @@
-import 'chai';
+import chai from 'chai';
 import routerStateReducer from '../router-state-reducer';
 
 describe('routerStateReducer', () => {
@@ -19,6 +19,7 @@ describe('routerStateReducer', () => {
     let action = {
       type: '@@reduxUiRouter/$stateChangeSuccess',
       payload: {
+        evt: 'evt',
         currentState: 'currentState',
         currentParams: 'currentParams',
         prevState: 'prevState',
@@ -27,6 +28,7 @@ describe('routerStateReducer', () => {
     };
 
     let state = routerStateReducer(undefined, action);
+    chai.should().not.exist(state.evt);
     expect(state.currentState).to.equal('currentState');
     expect(state.currentParams).to.equal('currentParams');
     expect(state.prevState).to.equal('prevState');

--- a/src/__tests__/state-change-error.test.js
+++ b/src/__tests__/state-change-error.test.js
@@ -10,6 +10,7 @@ describe('stateChangeError', () => {
     expect(action.payload.fromState).to.equal('fromState');
     expect(action.payload.fromParams).to.equal('fromParams');
     expect(action.payload.err).to.equal('err');
+    expect(action.payload.evt).to.equal('evt');
     expect(action.type).to.equal('@@reduxUiRouter/$stateChangeError');
   });
 });

--- a/src/__tests__/state-change-start.test.js
+++ b/src/__tests__/state-change-start.test.js
@@ -9,6 +9,7 @@ describe('stateChangeStart', () => {
     expect(action.payload.toParams).to.equal('toParams');
     expect(action.payload.fromState).to.equal('fromState');
     expect(action.payload.fromParams).to.equal('fromParams');
+    expect(action.payload.evt).to.equal('evt');
     expect(action.type).to.equal('@@reduxUiRouter/$stateChangeStart');
   });
 });

--- a/src/router-state-reducer.js
+++ b/src/router-state-reducer.js
@@ -16,7 +16,9 @@ const INITIAL_STATE = {
  * @return {Object} New state
  */
 export default function routerStateReducer(state = INITIAL_STATE, action) {
-  return action.type === STATE_CHANGE_SUCCESS
-    ? action.payload
-    : state;
+  if (action.type !== STATE_CHANGE_SUCCESS) {
+    return state;
+  }
+  delete action.payload.evt;
+  return action.payload;
 }

--- a/src/state-change-error.js
+++ b/src/state-change-error.js
@@ -18,6 +18,7 @@ export default function onStateChangeError(evt, toState, toParams, fromState, fr
   return {
     type: STATE_CHANGE_ERROR,
     payload: {
+      evt,
       toState,
       toParams,
       fromState,

--- a/src/state-change-start.js
+++ b/src/state-change-start.js
@@ -17,6 +17,7 @@ export default function onStateChangeStart(evt, toState, toParams, fromState, fr
   return {
     type: STATE_CHANGE_START,
     payload: {
+      evt,
       toState,
       toParams,
       fromState,


### PR DESCRIPTION
Passing the ui-router events in the payload allows to intercept them in a middleware and prevent the route change until some checks are passed. For example : check the user as access to the route.
The event is not passed to the store as it's a short lived object who at that point would only add noise.

Issue #34 