### PR TITLE
Add `href` property to the router state object

### DIFF
--- a/src/__tests__/router-listener.test.js
+++ b/src/__tests__/router-listener.test.js
@@ -44,7 +44,7 @@ describe('routerListener', () => {
     describe('onStart', () => {
       it('must call onStateChangeStart with the transition parameters', () => {
         $transitions.onStart.yield($transition$);
-        expect(ngUiStateChangeActions.onStateChangeStart.calledWith('to', 'toParams', 'from', 'fromParams')).to.equal(true);
+        expect(ngUiStateChangeActions.onStateChangeStart.calledWith('to', 'toParams', 'from', 'fromParams', 'href')).to.equal(true);
       });
     });
 
@@ -52,7 +52,7 @@ describe('routerListener', () => {
       it('must call onStateChangeError with the transition parameters and the transition Error', () => {
         $transition$.error = sinon.stub().returns('transitionError');
         $transitions.onError.yield($transition$);
-        expect(ngUiStateChangeActions.onStateChangeError.calledWith('to', 'toParams', 'from', 'fromParams', 'transitionError')).to.equal(true);
+        expect(ngUiStateChangeActions.onStateChangeError.calledWith('to', 'toParams', 'from', 'fromParams', 'href', 'transitionError')).to.equal(true);
       });
     });
 

--- a/src/router-middleware.js
+++ b/src/router-middleware.js
@@ -28,6 +28,7 @@ export default function routerMiddleware($state) {
         payload: {
           currentState: action.payload.toState,
           currentParams: action.payload.toParams,
+          href: $state.href,
           prevState: action.payload.fromState,
           prevParams: action.payload.fromParams,
         },


### PR DESCRIPTION
Adding `href` to the router state object gives access to the
`$state.href` function in React code. This allows the creation
of urls for states, which is critical when a component links to
another part of the app and should be crawlable by a crawler.