### PR TITLE
fix router middleware to return next action

### DIFF
--- a/src/router-middleware.js
+++ b/src/router-middleware.js
@@ -34,7 +34,7 @@ export default function routerMiddleware($state) {
         });
 
       default:
-        next(action);
+        return next(action);
     }
   };
 }


### PR DESCRIPTION
it's fixes issue when we want to get action after dispatched action
```javascript
store.dispatch(
  someAction()
).then((action) => {
  console.log(action) //undefined
})
```