### PR TITLE
Middleware default case should return

### DIFF
--- a/src/__tests__/state-middleware.test.js
+++ b/src/__tests__/state-middleware.test.js
@@ -24,17 +24,18 @@ describe('routerMiddleware', () => {
     $state.reload = sinon.stub().resolves('foo');
     $state.transitionTo = sinon.stub().resolves('foo');
 
-    nextSpy = sinon.stub();
+    nextSpy = sinon.stub().returns('foo');
   });
 
   it('should call the next action if the router middleware doesn\'t care about it', () => {
     let middleware = routerMiddleware($state)({})(nextSpy);
 
-    middleware({
+    let returnValue = middleware({
       payload: {}
     });
 
     expect(nextSpy.called).to.equal(true);
+    expect(returnValue).to.equal('foo');
     expect($state.go.called).to.equal(false);
     expect($state.reload.called).to.equal(false);
     expect($state.transitionTo.called).to.equal(false);

--- a/src/router-middleware.js
+++ b/src/router-middleware.js
@@ -34,7 +34,7 @@ export default function routerMiddleware($state) {
         });
 
       default:
-        next(action);
+        return next(action);
     }
   };
 }


### PR DESCRIPTION
The middleware's default case should return the `action(next)` value. This allows you to grab the result from thunks.

```javascript
let result = $ngRedux.dispatch(MyActions.doThing());
```

This pull request:

- Adds `return` statement to default case
- Adds `expect` test in *\__tests\__/state-middleware.test.js*