### PR TITLE
Changed the 'toParams' arg to 'params' in state-transitions-to.js and fixed tests

### DIFF
--- a/src/__tests__/state-transition-to.test.js
+++ b/src/__tests__/state-transition-to.test.js
@@ -5,7 +5,7 @@ describe('stateTransitionTo', () => {
   it('should create an action containing the state to transition to', () => {
     let action = stateTransitionTo('example', { test: 'hello' }, { option: 'world' });
     expect(action.payload.to).to.equal('example');
-    expect(action.payload.toParams.test).to.equal('hello');
+    expect(action.payload.params.test).to.equal('hello');
     expect(action.payload.options.option).to.equal('world');
     expect(action.type).to.equal('@@reduxUiRouter/transitionTo');
   });
@@ -13,7 +13,7 @@ describe('stateTransitionTo', () => {
   it('should create an action when to params are undefined', () => {
     let action = stateTransitionTo('example', undefined, undefined);
     expect(action.payload.to).to.equal('example');
-    expect(action.payload.toParams).to.equal(undefined);
+    expect(action.payload.params).to.equal(undefined);
     expect(action.payload.options).to.equal(undefined);
     expect(action.type).to.equal('@@reduxUiRouter/transitionTo');
   });

--- a/src/state-transition-to.js
+++ b/src/state-transition-to.js
@@ -7,16 +7,16 @@ import { STATE_TRANSITION_TO } from './action-types';
  * http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state
  *
  * @param  {String} to - State name
- * @param  {Object} toParams - (optional) Parameters to send with state
+ * @param  {Object} params - (optional) Parameters to send with state
  * @param  {Object} options - (optional) Options object
  * @return {Object} Action object
  */
-export default function stateTransitionTo(to, toParams, options) {
+export default function stateTransitionTo(to, params, options) {
   return {
     type: STATE_TRANSITION_TO,
     payload: {
       to,
-      toParams,
+      params,
       options,
     },
   };


### PR DESCRIPTION
Fixes stateTransitionTo() not binding the params to the payload with the correct name. The reducer was looking in payload.params and Redux was binding it to payload.toParams.