### PR TITLE
Adding `options` parameter to onStateChangeStart action creator

### DIFF
--- a/src/__tests__/state-change-start.test.js
+++ b/src/__tests__/state-change-start.test.js
@@ -3,12 +3,13 @@ import stateChangeStart from '../state-change-start';
 
 describe('stateChangeStart', () => {
   it('should create an action with the provided params', () => {
-    let action = stateChangeStart('evt', 'toState', 'toParams', 'fromState', 'fromParams');
+    let action = stateChangeStart('evt', 'toState', 'toParams', 'fromState', 'fromParams', 'options');
 
     expect(action.payload.toState).to.equal('toState');
     expect(action.payload.toParams).to.equal('toParams');
     expect(action.payload.fromState).to.equal('fromState');
     expect(action.payload.fromParams).to.equal('fromParams');
+    expect(action.payload.options).to.equal('options');
     expect(action.payload.evt).to.equal('evt');
     expect(action.type).to.equal('@@reduxUiRouter/$stateChangeStart');
   });

--- a/src/state-change-start.js
+++ b/src/state-change-start.js
@@ -11,9 +11,10 @@ import { STATE_CHANGE_START } from './action-types';
  * @param {Object} toParams To params object
  * @param {Object} fromState From state definition
  * @param {Object} fromParams From params object
+ * @param {Object} options Options object
  * @return {Object} Action object
  */
-export default function onStateChangeStart(evt, toState, toParams, fromState, fromParams) {
+export default function onStateChangeStart(evt, toState, toParams, fromState, fromParams, options) {
   return {
     type: STATE_CHANGE_START,
     payload: {
@@ -22,6 +23,7 @@ export default function onStateChangeStart(evt, toState, toParams, fromState, fr
       toParams,
       fromState,
       fromParams,
+      options,
     },
   };
 }


### PR DESCRIPTION
UI-Router passes the [`options` Object](http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state#methods_go) to its `$stateChangeStart` handler. The redux implementation just [drops it from the action creator](url). The `options` Object can be useful for middlewares.

Here's the ui-router implementation:
```
$rootScope.$on('$stateChangeStart', 
function(event, toState, toParams, fromState, fromParams, options){ ... })
```