### PR TITLE
Restrict to node v6 and higher because of yarn strict engine checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "angular-ui-router": "^1.0.0-beta.1"
   },
   "engines": {
-    "node": "6.3.0",
-    "npm": "3.10.3"
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Yarn is strict about checking the node & npm version, which makes redux-ui-router not usable with node versions different than 6.3.0.

```bash
$ node -v
v6.9.1

$ yarn add redux-ui-router
yarn add v0.16.1
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error redux-ui-router@0.6.0: The engine "node" is incompatible with this module. Expected version "6.3.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```