### PR TITLE
Add umd packages to npm repo via prepublish hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "main": "./lib/index.js",
   "scripts": {
     "lint": "node node_modules/.bin/eslint src",
-    "clean": "rm -rf lib",
+    "clean": "rm -rf lib && rm -rf dist",
     "test": "npm run lint; NODE_ENV=test node node_modules/.bin/mocha --compilers js:babel-register --recursive --require src/__tests__/index.js src/**/*.test.js",
     "test:live": "npm run lint; NODE_ENV=test node node_modules/.bin/mocha --compilers js:babel-register --recursive --require src/__tests__/index.js -w src/**/*.test.js",
-    "build": "npm run clean; npm run test; node node_modules/.bin/babel src --out-dir lib"
+    "build": "npm run clean; npm run test; node node_modules/.bin/babel src --out-dir lib",
+    "bundle:dev": "webpack --output-library=ngReduxUiRouter --output-library-target=umd lib/index.js dist/redux-ui-router.js",
+    "bundle:prod": "webpack -p --output-library=ngReduxUiRouter --output-library-target=umd lib/index.js dist/redux-ui-router.min.js",
+    "prepublish": "npm run build && npm run bundle:dev && npm run bundle:prod"
   },
   "repository": {
     "type": "git",
@@ -34,7 +37,8 @@
     "ng-redux": "^3.3.3",
     "node-libs-browser": "^1.0.0",
     "sinon": "1.17.4",
-    "sinon-as-promised": "^3.0.1"
+    "sinon-as-promised": "^3.0.1",
+    "webpack": "^2.4.1"
   },
   "peerDependencies": {
     "angular": "^1.4.x < 2.0.0",


### PR DESCRIPTION
Hello!

We're still stuck maintaining an application that isn't quite ready to migrate over to a package bundler such as webpack. As such, your library is unavailable to us, since no umd module is provided.

I've added umd module creation to the `prepublish` npm hook - it webpacks both a development (non-minified) version and production (minified) version on the fly to keep the git repository clean, but make these bundles available via npm installs. The bundles expose a global `ngReduxUiRouter` variable for in-browser use.

I'm currently testing this approach out using the v0.7.1-rc1, so would need a v0.7.1-rc2 to make this available on that track.

Thanks for your consideration and maintaining a nice bridge between ngRedux and ui-router!