### PR TITLE
Npm umd packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "npm run lint; NODE_ENV=test node node_modules/.bin/mocha --compilers js:babel-register --recursive --require src/__tests__/index.js src/**/*.test.js",
     "test:live": "npm run lint; NODE_ENV=test node node_modules/.bin/mocha --compilers js:babel-register --recursive --require src/__tests__/index.js -w src/**/*.test.js",
     "build": "npm run clean; npm run test; node node_modules/.bin/babel src --out-dir lib",
-    "bundle:dev": "webpack --output-library=ngReduxUiRouter --output-library-target=umd lib/index.js dist/redux-ui-router.js",
-    "bundle:prod": "webpack -p --output-library=ngReduxUiRouter --output-library-target=umd lib/index.js dist/redux-ui-router.min.js",
+    "bundle:dev": "webpack lib/index.js dist/redux-ui-router.js",
+    "bundle:prod": "webpack -p lib/index.js dist/redux-ui-router.min.js",
     "prepublish": "npm run build && npm run bundle:dev && npm run bundle:prod"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "main": "./lib/index.js",
   "scripts": {
     "lint": "node node_modules/.bin/eslint src",
-    "clean": "rm -rf lib",
+    "clean": "rm -rf lib && rm -rf dist",
     "test": "npm run lint; NODE_ENV=test node node_modules/.bin/mocha --compilers js:babel-register --recursive --require src/__tests__/index.js src/**/*.test.js",
     "test:live": "npm run lint; NODE_ENV=test node node_modules/.bin/mocha --compilers js:babel-register --recursive --require src/__tests__/index.js -w src/**/*.test.js",
-    "build": "npm run clean; npm run test; node node_modules/.bin/babel src --out-dir lib"
+    "build": "npm run clean; npm run test; node node_modules/.bin/babel src --out-dir lib",
+    "bundle:dev": "webpack --output-library=ngReduxUiRouter --output-library-target=umd lib/index.js dist/redux-ui-router.js",
+    "bundle:prod": "webpack -p --output-library=ngReduxUiRouter --output-library-target=umd lib/index.js dist/redux-ui-router.min.js",
+    "prepublish": "npm run build && npm run bundle:dev && npm run bundle:prod"
   },
   "repository": {
     "type": "git",
@@ -34,7 +37,8 @@
     "ng-redux": "^3.3.3",
     "node-libs-browser": "^1.0.0",
     "sinon": "1.17.4",
-    "sinon-as-promised": "^3.0.1"
+    "sinon-as-promised": "^3.0.1",
+    "webpack": "^2.4.1"
   },
   "peerDependencies": {
     "angular": "^1.4.x < 2.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  output: {
+    library: 'ngReduxUiRouter',
+    libraryTarget: 'umd'
+  },
+  externals: ['angular', 'angular-ui-router']
+};


### PR DESCRIPTION
Following up on #88 I realize we were bundling angular and angular-ui-router in the resulting library, which is bad form.

I've added a light webpack config to require angular and angular-ui-router as external libraries. This brings the bundle sizes down from 1.48M/221K (dev/prod) to 58K/12K and build times from 730ms/3000ms to 240ms/500ms. 