### PR TITLE
update `angular-ui-router` name to `@uirouter/angularjs`

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import uiRouter from 'angular-ui-router';
+import uiRouter from '@uirouter/angularjs';
 
 import ngRedux from 'ng-redux';
 import {combineReducers} from 'redux';

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "angular": "^1.5.1",
-    "angular-ui-router": "0.4.2",
+    "@uirouter/angularjs": "^1.0.3",
     "ng-redux": "^3.3.3",
     "redux": "^3.5.2",
     "redux-logger": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "redux": "^3.5.2"
   },
   "devDependencies": {
+    "@uirouter/angularjs": "^1.0.3",
     "angular": "^1.4.x < 2.0.0",
-    "angular-ui-router": "0.4.2",
     "babel-cli": "^6.11.4",
     "babel-core": "6.5.2",
     "babel-eslint": "6.1.2",
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "angular": "^1.4.x < 2.0.0",
-    "angular-ui-router": "^0.4.2"
+    "@uirouter/angularjs": "^1.0.3"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import uiRouter from 'angular-ui-router';
+import uiRouter from '@uirouter/angularjs';
 import routerState from './router-state-reducer';
 import stateGo from './state-go';
 import stateReload from './state-reload';


### PR DESCRIPTION
`angular-ui-router` name has been changed to `@uirouter/angularjs`, and it causes apps that using `redux-ui-router` to crash.