### PR TITLE
Update namespace of uirouter to ensure it is not included in the webpack bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,5 +3,5 @@ module.exports = {
     library: 'ngReduxUiRouter',
     libraryTarget: 'umd'
   },
-  externals: ['angular', 'angular-ui-router']
+  externals: ['angular', '@uirouter/angularjs']
 };


### PR DESCRIPTION
It appears that when ui-router updated their namespace to `@uirouter/angular-js`, redux-ui-router updated the imports but didn't update the webpack config, so the entire ui-router library was being included in the bundle.

This PR fixes an issue raised during [#28](https://github.com/neilff/redux-ui-router/issues/28#issuecomment-310774616)